### PR TITLE
Fix a couple of bugs in locating OpenCV.

### DIFF
--- a/cmake/FindOpenCV.cmake
+++ b/cmake/FindOpenCV.cmake
@@ -34,12 +34,11 @@ if (NOT OpenCV_INCLUDE_DIR)
       opencv2/core/core.hpp
     DOC 
       "OpenCV Include Directory"
-    #PATHS
-    #	/usr/local/include
-    #	/usr/include
+    PATHS
+    	/usr/local/include
+    	/usr/include
     )	
 endif()
-
 # ----------------------------------------------------------------------
 # Determine OpenCV version
 # ----------------------------------------------------------------------
@@ -105,6 +104,8 @@ if (NOT OpenCV_FOUND)
     PATHS
       /usr/lib 
       /usr/local/lib
+      /usr/lib64
+      /usr/local/lib64
     )
     
   if(OpenCV_LIBRARY_DIRS)


### PR DESCRIPTION
This fixes a couple of problems where CMake was unable to locate OpenCV on a system that has both 32-bit and 64-bit libraries. I have not been able to test this on more than Fedora 20, but this should work for other systems with both 'lib' and 'lib64' directories.