### PR TITLE
parsing fix: string hasn't a proper ending

### DIFF
--- a/src/socketio/src/packet.cpp
+++ b/src/socketio/src/packet.cpp
@@ -126,16 +126,16 @@ std::size_t Packet::read(const ConstBuffer& buf)
     BitReader reader(buf);
 
     // look up frame type
-    char frame;
-    reader.get(&frame, 1);
-    _frame = static_cast<Packet::Frame>(atoi(&frame));
+	char frame[2] = {'\0'};
+    reader.get(frame, 1);
+    _frame = static_cast<Packet::Frame>(atoi(frame));//alternative: std::stoi(std::string(frame, 1))
 
     if (_frame == Packet::Frame::Message) {
-
+    
         // look up packet type
-        char type;
-        reader.get(&type, 1);
-        _type = static_cast<Packet::Type>(atoi(&type));
+		char type[2] = {'\0'};
+        reader.get(type, 1);
+        _type = static_cast<Packet::Type>(atoi(type));//std::stoi(std::string(type, 1))
         // if (_type < TypeMin || _type > TypeMax) {
         //     WarnN(this) << "Invalid message type: " << _type << endl;
         //     return false;


### PR DESCRIPTION
strings in Release aren't touched by debugger. therefore \0 isn't added. It leads to crashes and unexpected behaviour