### PR TITLE
add uvpp.cpp, add include path for uvpp.h

### DIFF
--- a/src/uv/CMakeLists.txt
+++ b/src/uv/CMakeLists.txt
@@ -8,6 +8,7 @@ if(BUILD_MODULES AND BUILD_MODULE_uv)
   set(INCLUDE_INSTALL_DIR "${LibSourcey_VENDOR_INSTALL_DIR}/include")
   add_vendor_dependency(LIBUV libuv)
 
+  include_directories(../base/include)
   #include_dependency(LibUV) #REQUIRED
 
   define_sourcey_module(uv)

--- a/src/uv/src/uvpp.cpp
+++ b/src/uv/src/uvpp.cpp
@@ -1,0 +1,19 @@
+//
+// LibSourcey
+// Copyright (C) 2005, Sourcey <http://sourcey.com>
+//
+// LibSourcey is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// LibSourcey is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "scy/uv/uvpp.h"


### PR DESCRIPTION
I've solved 'uv' project compile problem.

1. add uvpp.cpp
Because 'uv' project has not any cpp file, so there is nothing out file after build.

2. add include path to CMakeLists.txt  
When compiling 'uv' project, I got error message like ''scy/error.h': No such file or directory'.

Thank you for your precious time and sharing valuable result.

