### PR TITLE
Get libsourcey to compile on Linux without FFMPEG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ elseif(MSYS)
 elseif(APPLE)
   set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} -ldl") # -lm -lz -llibc -lglibc #${LibSourcey_INCLUDE_LIBRARIES}
 elseif(UNIX)
-  set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} -lm -ldl") # -lz -lrt -lpulse-simple -lpulse -ljack -llibc -lglibc #${LibSourcey_INCLUDE_LIBRARIES}
+  set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} -lm -ldl -lrt") # -lz -lrt -lpulse-simple -lpulse -ljack -llibc -lglibc #${LibSourcey_INCLUDE_LIBRARIES}
 endif()
 
 if(MSVC)

--- a/src/av/include/scy/av/devicemanager.h
+++ b/src/av/include/scy/av/devicemanager.h
@@ -28,11 +28,23 @@
 #include "scy/av/ffmpeg.h"
 
 
+#ifdef HAVE_FFMPEG_AVDEVICE
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavdevice/avdevice.h>
 }
+#else
+typedef struct {
+} AVInputFormat;
+typedef struct {
+  const char *name;
+} AVOutputFormat;
+typedef struct {
+} AVFormatContext;
+#define av_find_input_format(ANY) (nullptr)
+#define av_oformat_next(ANY) (nullptr)
+#endif
 
 
 namespace scy {

--- a/src/av/src/devicemanager.cpp
+++ b/src/av/src/devicemanager.cpp
@@ -179,10 +179,6 @@ bool getInputDeviceList(const std::vector<std::string>& inputs, Device::Type typ
     AVFormatContext* ctx = nullptr;
     AVInputFormat* iformat = nullptr;
 
-    AVFormatContext* ctx = nullptr;
-    AVInputFormat* iformat = nullptr;
-
-
     iformat = findDefaultInputFormat(inputs);
     if (!iformat) {
         assert(0 && "no input formats");

--- a/src/av/src/devicemanager.cpp
+++ b/src/av/src/devicemanager.cpp
@@ -133,6 +133,10 @@ AVInputFormat* findDefaultInputFormat(const std::vector<std::string>& inputs)
 
 bool enumerateDeviceList(AVFormatContext* s, Device::Type type, std::vector<av::Device>& devices)
 {
+#ifndef HAVE_FFMPEG_AVDEVICE
+  devices.clear();
+  return false;
+#else
     int error;
     // AVDictionary *tmp = nullptr;
     AVDeviceInfoList* devlist = nullptr;
@@ -162,6 +166,7 @@ fail:
         avdevice_free_list_devices(&devlist);
 
     return !devices.empty();
+#endif
 }
 
 
@@ -170,7 +175,9 @@ bool getInputDeviceList(const std::vector<std::string>& inputs, Device::Type typ
 #ifndef HAVE_FFMPEG_AVDEVICE
     WarnL << "HAVE_FFMPEG_AVDEVICE not defined, cannot list input devices" << endl;
     return false;
-#endif
+#else
+    AVFormatContext* ctx = nullptr;
+    AVInputFormat* iformat = nullptr;
 
     AVFormatContext* ctx = nullptr;
     AVInputFormat* iformat = nullptr;
@@ -221,6 +228,7 @@ fail:
     avformat_free_context(ctx);
 
     return !devices.empty();
+#endif
 }
 
 
@@ -229,7 +237,7 @@ bool getOutputDeviceList(const std::vector<std::string>& outputs, Device::Type t
 #ifndef HAVE_FFMPEG_AVDEVICE
     WarnL << "HAVE_FFMPEG_AVDEVICE not defined, cannot list output devices" << endl;
     return false;
-#endif
+#else
 
     AVFormatContext* ctx = nullptr;
     AVOutputFormat* oformat = nullptr;
@@ -273,6 +281,7 @@ fail:
         avformat_free_context(ctx);
 
     return !devices.empty();
+#endif
 }
 
 

--- a/src/av/src/ffmpeg.cpp
+++ b/src/av/src/ffmpeg.cpp
@@ -164,4 +164,20 @@ void printEncoders(std::ostream& ost, const char* delim)
 } } // namespace scy::av
 
 
+#else
+
+namespace scy {
+namespace av {
+
+void initializeFFmpeg()
+{
+}
+
+
+void uninitializeFFmpeg()
+{
+}
+
+} } // namespace scy::av
+
 #endif

--- a/src/av/tests/avtests.h
+++ b/src/av/tests/avtests.h
@@ -58,7 +58,8 @@ static const int kInNumSamples = 1024;
 //
 
 // Prepare a dummy YUV image
-static void fillYuvImage(AVFrame* pict, int frame_index, int width, int height)
+#ifdef HAVE_FFMPEG
+static void fillYuvImage(AVFrame *pict, int frame_index, int width, int height)
 {
     int x, y, i;
     i = frame_index;
@@ -135,6 +136,7 @@ std::vector<double*> createTestAudioSamplesDBL(int numFrames, int nbSamples, con
     } while (--numFrames);
     return vec;
 }
+#endif
 
 
 // =============================================================================
@@ -144,6 +146,7 @@ class AudioEncoderTest: public Test
 {
     void run()
     {
+#ifdef HAVE_FFMPEG
         av::AudioEncoder encoder;
         auto& iparams = encoder.iparams;
         auto& oparams = encoder.oparams;
@@ -176,6 +179,7 @@ class AudioEncoderTest: public Test
         util::clearVector<>(testSamples);
 
         // TODO: verify data integrity
+#endif
     }
 };
 
@@ -187,6 +191,7 @@ class AudioResamplerTest: public Test
 {
     void run()
     {
+#ifdef HAVE_FFMPEG
         av::AudioResampler resampler;
         auto& iparams = resampler.iparams;
         auto& oparams = resampler.oparams;
@@ -215,6 +220,7 @@ class AudioResamplerTest: public Test
         util::clearVector<>(testSamples);
 
         // TODO: verify data integrity
+#endif
     }
 };
 

--- a/src/av/tests/avtests.h
+++ b/src/av/tests/avtests.h
@@ -54,7 +54,7 @@ static const int kInNumSamples = 1024;
 
 
 // =============================================================================
-// Heleprs
+// Helpers
 //
 
 // Prepare a dummy YUV image
@@ -232,6 +232,7 @@ class AudioBufferTest: public Test
 {
     void run()
     {
+#ifdef HAVE_FFMPEG
         av::AudioBuffer fifo;
         fifo.alloc("dbl", 2);
 
@@ -270,11 +271,12 @@ class AudioBufferTest: public Test
         // util::clearVector<>(testSamples);
 
         // TODO: verify data integrity
+#endif
     }
 };
 
 
-// #ifdef HAVE_FFMPEG
+#ifdef HAVE_FFMPEG
 
 // =============================================================================
 // Audio Capture Encoder
@@ -416,7 +418,7 @@ class AudioCaptureResamplerTest: public Test
     }
 };
 
-// #endif // HAVE_FFMPEG
+#endif // HAVE_FFMPEG
 
 
 // static const int kInAudioDeviceId = 0;


### PR DESCRIPTION
Most changes were to ifdef out references to FFMPEG data structures.

Also needed to add -lrt when compiling the UV components.  There's probably a better platform way to test for this library, but I'm really not familiar with CMake.

Thanks,
Michael.
