### PR TITLE
Build with FFMPEG on Apple

### DIFF
--- a/LibSourcey.cmake
+++ b/LibSourcey.cmake
@@ -187,7 +187,8 @@ if(MSVC)
 endif()
 
 if(APPLE)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework Foundation -framework AVFoundation -framework QTKit")
+  message("Including APPLE's foundation and AVFoundation frameworks")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework Foundation -framework AVFoundation")
   #set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /SAFESEH:NO")
   #set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /SAFESEH:NO")
 endif()
@@ -203,7 +204,7 @@ find_package(FFmpeg)
 
 # print_module_variables(FFmpeg)
 # print_module_variables(FFMPEG)
-# message(FATAL_ERROR "FFMPEG_FOUND: ${FFMPEG_FOUND}, WITH_FFMPEG: ${WITH_FFMPEG}")
+message("FFMPEG_FOUND: ${FFMPEG_FOUND}, WITH_FFMPEG: ${WITH_FFMPEG}")
 # message(FATAL_ERROR "BUILD_SAMPLES ${BUILD_SAMPLES}")
 # message(FATAL_ERROR "LibSourcey_INCLUDE_LIBRARIES ${LibSourcey_INCLUDE_LIBRARIES}")
 

--- a/LibSourcey.cmake
+++ b/LibSourcey.cmake
@@ -18,6 +18,8 @@ include(LibSourceyIncludes REQUIRED)
 include(LibSourceyModules REQUIRED)
 include(LibSourceyVersion REQUIRED)
 
+option(MSG_VERBOSE "Print more status messages in order to help debug." OFF)
+
 # ----------------------------------------------------------------------------
 # LibSourcey build components
 # ----------------------------------------------------------------------------
@@ -204,7 +206,6 @@ find_package(FFmpeg)
 
 # print_module_variables(FFmpeg)
 # print_module_variables(FFMPEG)
-message("FFMPEG_FOUND: ${FFMPEG_FOUND}, WITH_FFMPEG: ${WITH_FFMPEG}")
 # message(FATAL_ERROR "BUILD_SAMPLES ${BUILD_SAMPLES}")
 # message(FATAL_ERROR "LibSourcey_INCLUDE_LIBRARIES ${LibSourcey_INCLUDE_LIBRARIES}")
 

--- a/cmake/CMakeFindExtensions.cmake
+++ b/cmake/CMakeFindExtensions.cmake
@@ -43,16 +43,16 @@ macro(find_library_extended prefix)
 
   # print_module_variables(${prefix})
 
-  # message("*** Find library for ${prefix}")
-  # message("Debug Library: ${${prefix}_LIBRARY_DEBUG}")
-  # message("Release Library: ${${prefix}_LIBRARY_RELEASE}")
-  # message("Library: ${${prefix}_LIBRARY}")
-  # message("Debug Paths: ${${prefix}_PATHS_RELEASE}")
-  # message("Release Paths: ${${prefix}_PATHS_DEBUG}")
-  # message("Paths: ${${prefix}_PATHS}")
-  # message("Debug Names: ${${prefix}_NAMES_RELEASE}")
-  # message("Release Names: ${${prefix}_NAMES_DEBUG}")
-  # message("Names: ${${prefix}_NAMES}")
+  # message(STATUS "*** Find library for ${prefix}")
+  # message(STATUS "Debug Library: ${${prefix}_LIBRARY_DEBUG}")
+  # message(STATUS "Release Library: ${${prefix}_LIBRARY_RELEASE}")
+  # message(STATUS "Library: ${${prefix}_LIBRARY}")
+  # message(STATUS "Debug Paths: ${${prefix}_PATHS_RELEASE}")
+  # message(STATUS "Release Paths: ${${prefix}_PATHS_DEBUG}")
+  # message(STATUS "Paths: ${${prefix}_PATHS}")
+  # message(STATUS "Debug Names: ${${prefix}_NAMES_RELEASE}")
+  # message(STATUS "Release Names: ${${prefix}_NAMES_DEBUG}")
+  # message(STATUS "Names: ${${prefix}_NAMES}")
 
 endmacro(find_library_extended)
 
@@ -82,7 +82,6 @@ endmacro()
 #
 macro(set_module_found module)
   set(${module}_FOUND FALSE)
-  # set(${module}_FOUND FALSE PARENT_SCOPE)
 
   # Compile the list of required vars
   set(_${module}_REQUIRED_VARS ${module}_LIBRARIES) # ${module}_INCLUDE_DIRS
@@ -92,7 +91,7 @@ macro(set_module_found module)
     if (NOT ${module}_${component}_FOUND)
       message(FATAL_ERROR "Required ${module} component ${component} missing. Please recompile ${module} with ${component} enabled.")
     #else()
-      # message(STATUS "  - Required ${module} component ${component} found.")
+      message(STATUS "  - Required ${module} component ${component} found.")
     endif()
   endforeach()
 
@@ -101,10 +100,6 @@ macro(set_module_found module)
   set(${module}_LIBRARY_DIRS   ${${module}_LIBRARY_DIRS} CACHE STRING   "The ${module} library directories." FORCE)
   set(${module}_LIBRARIES      ${${module}_LIBRARIES}    CACHE STRING   "The ${module} libraries." FORCE)
   set(${module}_FOUND          ${${module}_FOUND}        CACHE BOOLEAN  "The ${module} found status." FORCE)
-  # set(${module}_INCLUDE_DIRS ${${module}_INCLUDE_DIRS} PARENT_SCOPE)
-  # set(${module}_LIBRARY_DIRS ${${module}_LIBRARY_DIRS} PARENT_SCOPE)
-  # set(${module}_LIBRARIES    ${${module}_LIBRARIES}  PARENT_SCOPE)
-  # set(${module}_FOUND        ${${module}_FOUND}    PARENT_SCOPE)
 
   # Ensure required variables have been set, or fail in error.
   # NOTE: Disabling find_package_handle_standard_args check since it's always
@@ -119,9 +114,8 @@ macro(set_module_found module)
   # Set the module as found.
   if (${module}_LIBRARIES)
     set(${module}_FOUND TRUE)
-    # set(${module}_FOUND TRUE PARENT_SCOPE)
   else()
-    message("Failed to locate ${module}. Please specify paths manually.")
+    message(WARNING "Failed to locate ${module}. Please specify paths manually.")
   endif()
 
   mark_as_advanced(${module}_INCLUDE_DIRS
@@ -140,13 +134,13 @@ endmacro()
 macro(set_component_found module component)
   set_component_alias(${module} ${component})
 
-  # message("${ALIAS_LIBRARIES}=${${ALIAS_LIBRARIES}}")
-  # message("${ALIAS_INCLUDE_DIRS}=${${ALIAS_INCLUDE_DIRS}}")
-  # message("${ALIAS_LIBRARY_DIRS}=${${ALIAS_LIBRARY_DIRS}}")
+  message(STATUS "${ALIAS_LIBRARIES}=${${ALIAS_LIBRARIES}}")
+  message(STATUS "${ALIAS_INCLUDE_DIRS}=${${ALIAS_INCLUDE_DIRS}}")
+  message(STATUS "${ALIAS_LIBRARY_DIRS}=${${ALIAS_LIBRARY_DIRS}}")
 
   #if (${module}_${component}_LIBRARIES AND ${module}_${component}_INCLUDE_DIRS)
   if (${ALIAS_LIBRARIES}) # AND ${ALIAS_INCLUDE_DIRS} (XXX_INCLUDE_DIRS may be empty)
-    # message(STATUS "  - ${module} ${component} found.")
+    message(STATUS "  - ${module} ${component} found.")
     set(${ALIAS_FOUND} TRUE)
     # set(${ALIAS_FOUND} TRUE PARENT_SCOPE)
 
@@ -161,13 +155,13 @@ macro(set_component_found module component)
     # set(${module}_LIBRARIES  ${${module}_LIBRARIES}  PARENT_SCOPE)
     # set(${module}_DEFINITIONS  ${${module}_DEFINITIONS}  PARENT_SCOPE)
 
-    # message("Find Component Paths=${module}:${component}:${library}:${header}")
-    # message("${ALIAS_INCLUDE_DIRS}=${${ALIAS_INCLUDE_DIRS}}")
-    # message("${ALIAS_RELEASE_LIBRARIES}=${${ALIAS_RELEASE_LIBRARIES}}")
-    # message("${ALIAS_DEBUG_LIBRARIES}=${${ALIAS_DEBUG_LIBRARIES}}")
-    # message("${ALIAS_LIBRARIES}=${${ALIAS_LIBRARIES}}")
-    # message("${module}_INCLUDE_DIRS=${${module}_INCLUDE_DIRS}")
-    # message("${module}_LIBRARIES=${${module}_LIBRARIES}")
+    # message(STATUS "Find Component Paths=${module}:${component}:${library}:${header}")
+    # message(STATUS "${ALIAS_INCLUDE_DIRS}=${${ALIAS_INCLUDE_DIRS}}")
+    # message(STATUS "${ALIAS_RELEASE_LIBRARIES}=${${ALIAS_RELEASE_LIBRARIES}}")
+    # message(STATUS "${ALIAS_DEBUG_LIBRARIES}=${${ALIAS_DEBUG_LIBRARIES}}")
+    # message(STATUS "${ALIAS_LIBRARIES}=${${ALIAS_LIBRARIES}}")
+    # message(STATUS "${module}_INCLUDE_DIRS=${${module}_INCLUDE_DIRS}")
+    # message(STATUS "${module}_LIBRARIES=${${module}_LIBRARIES}")
 
     # Only mark as advanced when found
     mark_as_advanced(${ALIAS_INCLUDE_DIRS}
@@ -254,16 +248,18 @@ endmacro()
 # Finds the given component library and include paths.
 #
 macro(find_component_paths module component library header)
-  # message(STATUS "Find Component Paths=${module}:${component}:${library}:${header}")
+  message(STATUS "Find Component Paths=${module}:${component}:${library}:${header}")
+  message(STATUS "INCLUDE_DIR: ${${module}_INCLUDE_DIR} HINTS: ${${module}_INCLUDE_HINTS}")
 
   # Reset alias namespace (force recheck)
   set_component_alias(${module} ${component})
   set_component_notfound(${module} ${component})
 
   find_path(${ALIAS_INCLUDE_DIRS} ${header}
+    HINTS
+      ${${module}_INCLUDE_HINTS}
     PATHS
-      ${${module}_INCLUDE_DIR}   # try find from root module include dir
-      ${${module}_INCLUDE_HINTS} # try find from root module include hints
+      ${${module}_INCLUDE_DIR}
     PATH_SUFFIXES
       ${${module}_INCLUDE_SUFFIXES} # try find from root module include suffixes
   )
@@ -276,20 +272,22 @@ macro(find_component_paths module component library header)
     find_library(${ALIAS_RELEASE_LIBRARIES}
       NAMES
         ${library}
+      HINTS
+        ${${module}_LIBRARY_HINTS}
       PATHS
         ${${ALIAS_LIBRARY_DIRS}}
         ${${module}_LIBRARY_DIR}
-        ${${module}_LIBRARY_HINTS}
       PATH_SUFFIXES
         ${${module}_LIBRARY_SUFFIXES}
     )
     find_library(${ALIAS_DEBUG_LIBRARIES}
       NAMES
         ${library}d
+      HINTS
+        ${${module}_LIBRARY_HINTS}
       PATHS
         ${${ALIAS_LIBRARY_DIRS}}
         ${${module}_LIBRARY_DIR}
-        ${${module}_LIBRARY_HINTS}
       PATH_SUFFIXES
         ${${module}_LIBRARY_SUFFIXES}
     )
@@ -305,10 +303,11 @@ macro(find_component_paths module component library header)
     find_library(${ALIAS_LIBRARIES}
       NAMES
         ${library}
+      HINTS
+        ${${module}_LIBRARY_HINTS}
       PATHS
         ${${ALIAS_LIBRARY_DIRS}}
         ${${module}_LIBRARY_DIR}
-        ${${module}_LIBRARY_HINTS}
       PATH_SUFFIXES
         ${${module}_LIBRARY_SUFFIXES}
     )
@@ -325,27 +324,31 @@ endmacro()
 # libraries and include directories.
 #
 macro(find_component module component pkgconfig library header)
-  # message("Find Component=${module}:${component}:${pkgconfig}:${library}:${header}")
+   message(STATUS "Find Component=${module}:${component}:${pkgconfig}:${library}:${header}")
 
   # Reset component alias values (force recheck)
   set_component_alias(${module} ${component})
 
-  # Use pkg-config to obtain directories for the find_path() and find_library() calls.
-  find_package(PkgConfig QUIET)
-  if (PKG_CONFIG_FOUND)
-    pkg_search_module(${ALIAS} ${pkgconfig} QUIET)
-    # message(STATUS "Find Component PkgConfig=${ALIAS}:${${ALIAS}_FOUND}:${${ALIAS}_LIBRARIES}:${${ALIAS}_INCLUDE_DIRS}:${${ALIAS}_LIBRARY_DIRS}:${${ALIAS}_LIBDIR}:${${ALIAS}_INCLUDEDIR}")
-  endif()
-
-  # message(STATUS "${ALIAS_FOUND}=${${ALIAS_FOUND}}")
-  # message(STATUS "${ALIAS_LIBRARIES}=${${ALIAS_LIBRARIES}}")
-  # message(STATUS "${ALIAS_INCLUDE_DIRS}=${${ALIAS_INCLUDE_DIRS}}")
+  find_component_paths(${module} ${component} ${library} ${header})
 
   if(NOT ${ALIAS_FOUND})
-    # message(STATUS "  - ${module} ${component} pkg-config not found, searching...")
-    find_component_paths(${module} ${component} ${library} ${header})
+    message(STATUS "  - ${module} ${component} not found, searching with pkg-config...")
+
+    # Use pkg-config to obtain directories for the find_path() and find_library() calls.
+    find_package(PkgConfig QUIET)
+    if (PKG_CONFIG_FOUND)
+      pkg_search_module(${ALIAS} ${pkgconfig} QUIET)
+       message(STATUS "Find Component PkgConfig=${ALIAS}:${${ALIAS}_FOUND}:${${ALIAS}_LIBRARIES}:${${ALIAS}_INCLUDE_DIRS}:${${ALIAS}_LIBRARY_DIRS}:${${ALIAS}_LIBDIR}:${${ALIAS}_INCLUDEDIR}")
+    endif()
   else()
-    # message(STATUS "  - ${module} ${component} pkg-config found.")
+    message(STATUS "  - ${module} ${component} found without pkg-config.")
+  endif()
+
+  message(STATUS "${ALIAS_FOUND}=${${ALIAS_FOUND}}")
+  message(STATUS "${ALIAS_LIBRARIES}=${${ALIAS_LIBRARIES}}")
+  message(STATUS "${ALIAS_INCLUDE_DIRS}=${${ALIAS_INCLUDE_DIRS}}")
+
+  if( ${ALIAS_FOUND})
     set_component_found(${module} ${component})
   endif()
 endmacro()

--- a/cmake/CMakeFindExtensions.cmake
+++ b/cmake/CMakeFindExtensions.cmake
@@ -43,16 +43,16 @@ macro(find_library_extended prefix)
 
   # print_module_variables(${prefix})
 
-  # message(STATUS "*** Find library for ${prefix}")
-  # message(STATUS "Debug Library: ${${prefix}_LIBRARY_DEBUG}")
-  # message(STATUS "Release Library: ${${prefix}_LIBRARY_RELEASE}")
-  # message(STATUS "Library: ${${prefix}_LIBRARY}")
-  # message(STATUS "Debug Paths: ${${prefix}_PATHS_RELEASE}")
-  # message(STATUS "Release Paths: ${${prefix}_PATHS_DEBUG}")
-  # message(STATUS "Paths: ${${prefix}_PATHS}")
-  # message(STATUS "Debug Names: ${${prefix}_NAMES_RELEASE}")
-  # message(STATUS "Release Names: ${${prefix}_NAMES_DEBUG}")
-  # message(STATUS "Names: ${${prefix}_NAMES}")
+  # messageV("*** Find library for ${prefix}")
+  # messageV("Debug Library: ${${prefix}_LIBRARY_DEBUG}")
+  # messageV("Release Library: ${${prefix}_LIBRARY_RELEASE}")
+  # messageV("Library: ${${prefix}_LIBRARY}")
+  # messageV("Debug Paths: ${${prefix}_PATHS_RELEASE}")
+  # messageV("Release Paths: ${${prefix}_PATHS_DEBUG}")
+  # messageV("Paths: ${${prefix}_PATHS}")
+  # messageV("Debug Names: ${${prefix}_NAMES_RELEASE}")
+  # messageV("Release Names: ${${prefix}_NAMES_DEBUG}")
+  # messageV("Names: ${${prefix}_NAMES}")
 
 endmacro(find_library_extended)
 
@@ -91,7 +91,7 @@ macro(set_module_found module)
     if (NOT ${module}_${component}_FOUND)
       message(FATAL_ERROR "Required ${module} component ${component} missing. Please recompile ${module} with ${component} enabled.")
     #else()
-      message(STATUS "  - Required ${module} component ${component} found.")
+      messageV("  - Required ${module} component ${component} found.")
     endif()
   endforeach()
 
@@ -134,13 +134,13 @@ endmacro()
 macro(set_component_found module component)
   set_component_alias(${module} ${component})
 
-  message(STATUS "${ALIAS_LIBRARIES}=${${ALIAS_LIBRARIES}}")
-  message(STATUS "${ALIAS_INCLUDE_DIRS}=${${ALIAS_INCLUDE_DIRS}}")
-  message(STATUS "${ALIAS_LIBRARY_DIRS}=${${ALIAS_LIBRARY_DIRS}}")
+  messageV("${ALIAS_LIBRARIES}=${${ALIAS_LIBRARIES}}")
+  messageV("${ALIAS_INCLUDE_DIRS}=${${ALIAS_INCLUDE_DIRS}}")
+  messageV("${ALIAS_LIBRARY_DIRS}=${${ALIAS_LIBRARY_DIRS}}")
 
   #if (${module}_${component}_LIBRARIES AND ${module}_${component}_INCLUDE_DIRS)
   if (${ALIAS_LIBRARIES}) # AND ${ALIAS_INCLUDE_DIRS} (XXX_INCLUDE_DIRS may be empty)
-    message(STATUS "  - ${module} ${component} found.")
+    messageV("  - ${module} ${component} found.")
     set(${ALIAS_FOUND} TRUE)
     # set(${ALIAS_FOUND} TRUE PARENT_SCOPE)
 
@@ -155,13 +155,13 @@ macro(set_component_found module component)
     # set(${module}_LIBRARIES  ${${module}_LIBRARIES}  PARENT_SCOPE)
     # set(${module}_DEFINITIONS  ${${module}_DEFINITIONS}  PARENT_SCOPE)
 
-    # message(STATUS "Find Component Paths=${module}:${component}:${library}:${header}")
-    # message(STATUS "${ALIAS_INCLUDE_DIRS}=${${ALIAS_INCLUDE_DIRS}}")
-    # message(STATUS "${ALIAS_RELEASE_LIBRARIES}=${${ALIAS_RELEASE_LIBRARIES}}")
-    # message(STATUS "${ALIAS_DEBUG_LIBRARIES}=${${ALIAS_DEBUG_LIBRARIES}}")
-    # message(STATUS "${ALIAS_LIBRARIES}=${${ALIAS_LIBRARIES}}")
-    # message(STATUS "${module}_INCLUDE_DIRS=${${module}_INCLUDE_DIRS}")
-    # message(STATUS "${module}_LIBRARIES=${${module}_LIBRARIES}")
+    # messageV("Find Component Paths=${module}:${component}:${library}:${header}")
+    # messageV("${ALIAS_INCLUDE_DIRS}=${${ALIAS_INCLUDE_DIRS}}")
+    # messageV("${ALIAS_RELEASE_LIBRARIES}=${${ALIAS_RELEASE_LIBRARIES}}")
+    # messageV("${ALIAS_DEBUG_LIBRARIES}=${${ALIAS_DEBUG_LIBRARIES}}")
+    # messageV("${ALIAS_LIBRARIES}=${${ALIAS_LIBRARIES}}")
+    # messageV("${module}_INCLUDE_DIRS=${${module}_INCLUDE_DIRS}")
+    # messageV("${module}_LIBRARIES=${${module}_LIBRARIES}")
 
     # Only mark as advanced when found
     mark_as_advanced(${ALIAS_INCLUDE_DIRS}
@@ -170,7 +170,7 @@ macro(set_component_found module component)
   else()
     # NOTE: an error message will be displayed in set_module_found
     # if the module is REQUIRED
-    # message(STATUS "  - ${module} ${component} not found.")
+    # messageV("  - ${module} ${component} not found.")
   endif()
 
   set(HAVE_${ALIAS} ${${ALIAS_FOUND}})
@@ -195,7 +195,7 @@ endmacro()
 # Marks the given component as not found, and resets the cache for find_path and find_library results.
 #
 macro(set_module_notfound module)
-  #message(STATUS "  - Setting ${module} not found.")
+  #messageV("  - Setting ${module} not found.")
   set(${module}_FOUND FALSE)
   #set(${module}_FOUND FALSE PARENT_SCOPE)
 
@@ -222,7 +222,7 @@ endmacro()
 macro(set_component_notfound module component)
   set_component_alias(${module} ${component})
 
-  #message(STATUS "  - Setting ${module} ${component} not found.")
+  #messageV("  - Setting ${module} ${component} not found.")
   set(${ALIAS_FOUND} FALSE)
   #set(${ALIAS_FOUND} FALSE PARENT_SCOPE)
   set(${ALIAS_INCLUDE_DIRS} ${ALIAS_INCLUDE_DIRS}-NOTFOUND)
@@ -248,8 +248,8 @@ endmacro()
 # Finds the given component library and include paths.
 #
 macro(find_component_paths module component library header)
-  message(STATUS "Find Component Paths=${module}:${component}:${library}:${header}")
-  message(STATUS "INCLUDE_DIR: ${${module}_INCLUDE_DIR} HINTS: ${${module}_INCLUDE_HINTS}")
+  messageV("Find Component Paths=${module}:${component}:${library}:${header}")
+  messageV("INCLUDE_DIR: ${${module}_INCLUDE_DIR} HINTS: ${${module}_INCLUDE_HINTS}")
 
   # Reset alias namespace (force recheck)
   set_component_alias(${module} ${component})
@@ -324,7 +324,7 @@ endmacro()
 # libraries and include directories.
 #
 macro(find_component module component pkgconfig library header)
-   message(STATUS "Find Component=${module}:${component}:${pkgconfig}:${library}:${header}")
+   messageV("Find Component=${module}:${component}:${pkgconfig}:${library}:${header}")
 
   # Reset component alias values (force recheck)
   set_component_alias(${module} ${component})
@@ -332,21 +332,21 @@ macro(find_component module component pkgconfig library header)
   find_component_paths(${module} ${component} ${library} ${header})
 
   if(NOT ${ALIAS_FOUND})
-    message(STATUS "  - ${module} ${component} not found, searching with pkg-config...")
+    messageV("  - ${module} ${component} not found, searching with pkg-config...")
 
     # Use pkg-config to obtain directories for the find_path() and find_library() calls.
     find_package(PkgConfig QUIET)
     if (PKG_CONFIG_FOUND)
       pkg_search_module(${ALIAS} ${pkgconfig} QUIET)
-       message(STATUS "Find Component PkgConfig=${ALIAS}:${${ALIAS}_FOUND}:${${ALIAS}_LIBRARIES}:${${ALIAS}_INCLUDE_DIRS}:${${ALIAS}_LIBRARY_DIRS}:${${ALIAS}_LIBDIR}:${${ALIAS}_INCLUDEDIR}")
+       messageV("Find Component PkgConfig=${ALIAS}:${${ALIAS}_FOUND}:${${ALIAS}_LIBRARIES}:${${ALIAS}_INCLUDE_DIRS}:${${ALIAS}_LIBRARY_DIRS}:${${ALIAS}_LIBDIR}:${${ALIAS}_INCLUDEDIR}")
     endif()
   else()
-    message(STATUS "  - ${module} ${component} found without pkg-config.")
+    messageV("  - ${module} ${component} found without pkg-config.")
   endif()
 
-  message(STATUS "${ALIAS_FOUND}=${${ALIAS_FOUND}}")
-  message(STATUS "${ALIAS_LIBRARIES}=${${ALIAS_LIBRARIES}}")
-  message(STATUS "${ALIAS_INCLUDE_DIRS}=${${ALIAS_INCLUDE_DIRS}}")
+  messageV("${ALIAS_FOUND}=${${ALIAS_FOUND}}")
+  messageV("${ALIAS_LIBRARIES}=${${ALIAS_LIBRARIES}}")
+  messageV("${ALIAS_INCLUDE_DIRS}=${${ALIAS_INCLUDE_DIRS}}")
 
   if( ${ALIAS_FOUND})
     set_component_found(${module} ${component})

--- a/cmake/CMakeHelpers.cmake
+++ b/cmake/CMakeHelpers.cmake
@@ -219,3 +219,16 @@ function(status text)
     message(STATUS "${text}")
   endif()
 endfunction()
+
+#
+### Macro: messageV
+#
+# Prints message only with MSG_VERBOSE=ON
+# Usage:
+#   messageV(<msg>)
+#
+macro(messageV msg)
+  if(${MSG_VERBOSE})
+    message(STATUS msg)
+  endif()
+endmacro()

--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -18,11 +18,11 @@
 #   - POSTPROC
 #
 # the following variables will be defined
-#  <component>_FOUND        - System has <component>
-#  <component>_INCLUDE_DIRS - Include directory necessary for using the <component> headers
-#  <component>_LIBRARIES    - Link these to use <component>
-#  <component>_DEFINITIONS  - Compiler switches required for using <component>
-#  <component>_VERSION      - The components version
+#  FFmpeg_<component>_FOUND        - System has <component>
+#  FFmpeg_<component>_INCLUDE_DIRS - Include directory necessary for using the <component> headers
+#  FFmpeg_<component>_LIBRARIES    - Link these to use <component>
+#  FFmpeg_<component>_DEFINITIONS  - Compiler switches required for using <component>
+#  FFmpeg_<component>_VERSION      - The components version
 
 # The default components were taken from a survey over other FindFFmpeg.cmake files
 if (NOT FFmpeg_FIND_COMPONENTS)
@@ -35,14 +35,17 @@ if (NOT FFmpeg_FOUND)
   # The FFmpeg compilation guide stores files in an unusual location,
   # so let's support that out of the box
   # http://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu
+
+  option(FFMPEGDIR "User definable FFMPEG Root build directory" "/tmp/ffmpeg_build")
+
   set(FFmpeg_LIBRARY_HINTS
+    ${FFMPEGDIR}/lib
     $ENV{HOME}/tmp/ffmpeg_build/lib
-    $ENV{HOME}/ffmpeg_build/lib
-    /tmp/ffmpeg_build/lib)
+    $ENV{HOME}/ffmpeg_build/lib)
   set(FFmpeg_INCLUDE_HINTS
+    ${FFMPEGDIR}/include
     $ENV{HOME}/tmp/ffmpeg_build/include
-    $ENV{HOME}/ffmpeg_build/include
-    /tmp/ffmpeg_build/include)
+    $ENV{HOME}/ffmpeg_build/include)
 
   # Check for all components
   find_component(FFmpeg SWRESAMPLE libswresample swresample libswresample/swresample.h)
@@ -135,43 +138,46 @@ if (NOT FFmpeg_FOUND)
 endif()
 
 # Cache the vars.
-# set(FFmpeg_INCLUDE_DIRS ${FFmpeg_INCLUDE_DIRS} CACHE STRING   "The FFmpeg include directories." FORCE)
-# set(FFmpeg_LIBRARIES    ${FFmpeg_LIBRARIES}    CACHE STRING   "The FFmpeg libraries." FORCE)
-# set(FFmpeg_DEFINITIONS  ${FFmpeg_DEFINITIONS}  CACHE STRING   "The FFmpeg cflags." FORCE)
-# set(FFmpeg_FOUND        ${FFmpeg_FOUND}        CACHE BOOLEAN  "The FFmpeg found status." FORCE)
+ set(FFmpeg_INCLUDE_DIRS ${FFmpeg_INCLUDE_DIRS} CACHE STRING   "The FFmpeg include directories." FORCE)
+ set(FFmpeg_LIBRARIES    ${FFmpeg_LIBRARIES}    CACHE STRING   "The FFmpeg libraries." FORCE)
+ set(FFmpeg_DEFINITIONS  ${FFmpeg_DEFINITIONS}  CACHE STRING   "The FFmpeg cflags." FORCE)
+ set(FFmpeg_FOUND        ${FFmpeg_FOUND}        CACHE BOOLEAN  "The FFmpeg found status." FORCE)
 
 # Check that the required components were found.
-# set(FFmpeg_FOUND 1)
-# foreach (_component ${FFmpeg_FIND_COMPONENTS})
-#  if (FFmpeg_${_component}_FOUND)
-#    message(STATUS "Required component ${_component} present.")
-#  else ()
-#    message(STATUS "Required component ${_component} missing.")
-#    set(FFmpeg_FOUND 0)
-#  endif ()
-# endforeach ()
+set(FFmpeg_FOUND 1)
+foreach (_component ${FFmpeg_FIND_COMPONENTS})
+if (FFmpeg_${_component}_FOUND)
+  message(STATUS "Required component ${_component} present.")
+else ()
+  message(STATUS "Required component ${_component} missing.")
+  set(FFmpeg_FOUND 0)
+endif ()
+endforeach ()
 
 # Build the include path with duplicates removed.
-# if (FFmpeg_INCLUDE_DIRS)
-#  list(REMOVE_DUPLICATES FFmpeg_INCLUDE_DIRS)
-# endif ()
+if (FFmpeg_INCLUDE_DIRS)
+  list(REMOVE_DUPLICATES FFmpeg_INCLUDE_DIRS)
+endif ()
 
 # Now set the noncached _FOUND vars for the components.
-# foreach (_component AVCODEC AVDEVICE AVFORMAT AVUTIL POSTPROCESS SWSCALE) #AVFILTER
-#  set_component_found(${_component})
-# endforeach ()
+ foreach (_component AVCODEC AVDEVICE AVFORMAT AVUTIL POSTPROC SWSCALE) #AVFILTER
+  set_component_found(FFmpeg ${_component})
+  message(STATUS "FFmpeg component ${_component} FOUND? ${FFmpeg_${_component}_FOUND}")
+ endforeach ()
 
 # Compile the list of required vars
-# set(_FFmpeg_REQUIRED_VARS FFmpeg_LIBRARIES FFmpeg_INCLUDE_DIRS)
-# foreach (_component ${FFmpeg_FIND_COMPONENTS})
-#   list(APPEND _FFmpeg_REQUIRED_VARS ${_component}_LIBRARIES ${_component}_INCLUDE_DIRS)
-# endforeach ()
+ set(_FFmpeg_REQUIRED_VARS FFmpeg_LIBRARIES FFmpeg_INCLUDE_DIRS)
+ foreach (_component ${FFmpeg_FIND_COMPONENTS})
+   list(APPEND _FFmpeg_REQUIRED_VARS FFmpeg_${_component}_LIBRARIES FFmpeg_${_component}_INCLUDE_DIRS)
+ endforeach ()
 
 # Give a nice error message if some of the required vars are missing.
-# include(FindPackageHandleStandardArgs)
-# find_package_handle_standard_args(FFmpeg DEFAULT_MSG ${_FFmpeg_REQUIRED_VARS})
-#
-# mark_as_advanced(FFmpeg_INCLUDE_DIRS
-#                  FFmpeg_LIBRARIES
-#                  FFmpeg_DEFINITIONS
-#                  FFmpeg_FOUND)
+include(FindPackageHandleStandardArgs)
+message(STATUS ${_FFmpeg_REQUIRED_VARS})
+find_package_handle_standard_args(FFmpeg DEFAULT_MSG ${_FFmpeg_REQUIRED_VARS})
+mark_as_advanced(FFmpeg_INCLUDE_DIRS
+                FFmpeg_LIBRARIES
+                FFmpeg_DEFINITIONS
+                FFmpeg_FOUND)
+
+message(STATUS "Finished Find FFmpeg")

--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -24,6 +24,8 @@
 #  FFmpeg_<component>_DEFINITIONS  - Compiler switches required for using <component>
 #  FFmpeg_<component>_VERSION      - The components version
 
+message("Starting Find FFmpeg")
+
 # The default components were taken from a survey over other FindFFmpeg.cmake files
 if (NOT FFmpeg_FIND_COMPONENTS)
   set(FFmpeg_FIND_COMPONENTS AVCODEC AVFORMAT AVUTIL AVDEVICE SWSCALE SWRESAMPLE)
@@ -147,9 +149,9 @@ endif()
 set(FFmpeg_FOUND 1)
 foreach (_component ${FFmpeg_FIND_COMPONENTS})
 if (FFmpeg_${_component}_FOUND)
-  message(STATUS "Required component ${_component} present.")
+  messageV( "Required component ${_component} present.")
 else ()
-  message(STATUS "Required component ${_component} missing.")
+  message(WARNING "Required component ${_component} missing.")
   set(FFmpeg_FOUND 0)
 endif ()
 endforeach ()
@@ -162,7 +164,7 @@ endif ()
 # Now set the noncached _FOUND vars for the components.
  foreach (_component AVCODEC AVDEVICE AVFORMAT AVUTIL POSTPROC SWSCALE) #AVFILTER
   set_component_found(FFmpeg ${_component})
-  message(STATUS "FFmpeg component ${_component} FOUND? ${FFmpeg_${_component}_FOUND}")
+  messageV("FFmpeg component ${_component} FOUND? ${FFmpeg_${_component}_FOUND}")
  endforeach ()
 
 # Compile the list of required vars
@@ -173,11 +175,10 @@ endif ()
 
 # Give a nice error message if some of the required vars are missing.
 include(FindPackageHandleStandardArgs)
-message(STATUS ${_FFmpeg_REQUIRED_VARS})
 find_package_handle_standard_args(FFmpeg DEFAULT_MSG ${_FFmpeg_REQUIRED_VARS})
 mark_as_advanced(FFmpeg_INCLUDE_DIRS
                 FFmpeg_LIBRARIES
                 FFmpeg_DEFINITIONS
                 FFmpeg_FOUND)
 
-message(STATUS "Finished Find FFmpeg")
+message("Finished Find FFmpeg")

--- a/src/av/src/apple/avfoundation.cpp
+++ b/src/av/src/apple/avfoundation.cpp
@@ -9,6 +9,7 @@
 /// @{
 
 
+#include "scy/logger.h"
 #include <ostream>
 #include "scy/av/apple/avfoundation.h"
 


### PR DESCRIPTION
find_component was defaulting to pkgconfig, which is great, but it means that it did not respect my hints for FFMPEG custom build. I'm sure this can be re-orderable using a optional flag.

Another of my issues was with Find_FFmpeg having a bunch of commented out code, so variables would not get filled out. I also added a FFMPEGDIR option so that a user can specify a root directory in case the defaults do not exist.

I also removed QTKit from the linker flags.

I added a messageV macro in order to print messages only with -DMSG_VERSBOSE=ON, maybe there is a better way. This is useful to print out the status messages of the find results to make sure the correct lib is being used.