### PR TITLE
Fix webrtc record Fail

### DIFF
--- a/src/av/include/scy/av/multiplexencoder.h
+++ b/src/av/include/scy/av/multiplexencoder.h
@@ -100,6 +100,7 @@ protected:
     AVIOContext* _ioCtx;
     uint8_t* _ioBuffer;
     uint64_t _pts;
+	mutable std::mutex _mutex;
 };
 
 

--- a/src/av/include/scy/av/multiplexencoder.h
+++ b/src/av/include/scy/av/multiplexencoder.h
@@ -100,7 +100,7 @@ protected:
     AVIOContext* _ioCtx;
     uint8_t* _ioBuffer;
     uint64_t _pts;
-	mutable std::mutex _mutex;
+    mutable std::mutex _mutex;
 };
 
 

--- a/src/av/src/multiplexencoder.cpp
+++ b/src/av/src/multiplexencoder.cpp
@@ -411,7 +411,7 @@ bool MultiplexEncoder::encodeVideo(uint8_t* buffer, int bufferSize,
 
 void MultiplexEncoder::onVideoEncoded(av::VideoPacket& packet)
 {
-	std::lock_guard<std::mutex> guard(_mutex);
+    std::lock_guard<std::mutex> guard(_mutex);
     writeOutputPacket(*reinterpret_cast<AVPacket*>(packet.source));
 }
 
@@ -501,7 +501,7 @@ bool MultiplexEncoder::encodeAudio(uint8_t* buffer[4], int numSamples, int64_t t
 
 void MultiplexEncoder::onAudioEncoded(av::AudioPacket& packet)
 {
-	std::lock_guard<std::mutex> guard(_mutex);
+    std::lock_guard<std::mutex> guard(_mutex);
     writeOutputPacket(*reinterpret_cast<AVPacket*>(packet.source));
 }
 

--- a/src/av/src/multiplexencoder.cpp
+++ b/src/av/src/multiplexencoder.cpp
@@ -411,6 +411,7 @@ bool MultiplexEncoder::encodeVideo(uint8_t* buffer, int bufferSize,
 
 void MultiplexEncoder::onVideoEncoded(av::VideoPacket& packet)
 {
+	std::lock_guard<std::mutex> guard(_mutex);
     writeOutputPacket(*reinterpret_cast<AVPacket*>(packet.source));
 }
 
@@ -500,6 +501,7 @@ bool MultiplexEncoder::encodeAudio(uint8_t* buffer[4], int numSamples, int64_t t
 
 void MultiplexEncoder::onAudioEncoded(av::AudioPacket& packet)
 {
+	std::lock_guard<std::mutex> guard(_mutex);
     writeOutputPacket(*reinterpret_cast<AVPacket*>(packet.source));
 }
 


### PR DESCRIPTION
Fix webrtc record Fail

av_interleaved_write_frame will return false,without lock.
when i push stream to rtmp server failed,i find it is av_interleaved_write_frame fail.so need to open stream again.