### PR TITLE
Correct uv::runLoop() calls in stuntests

### DIFF
--- a/src/symple/tests/sympletests.cpp
+++ b/src/symple/tests/sympletests.cpp
@@ -88,7 +88,7 @@ int main(int argc, char** argv)
         while (!lclient.completed() || !rclient.completed()) {
 
             // DebugL << "waiting for test completion" << std::endl;
-            uv::runLoop(UV_RUN_ONCE);
+            uv::runLoop(uv::defaultLoop(), UV_RUN_ONCE);
 
             // // Connect the rclient when lclient is online
             // if (lclient.client.isOnline() &&

--- a/src/symple/tests/sympletests.h
+++ b/src/symple/tests/sympletests.h
@@ -216,7 +216,7 @@ bool openTestServer(Process& proc, bool install = true)
 
     // Run the loop until the server is listening or exited in failure
     while (!exited && !running) {
-        uv::runLoop(UV_RUN_NOWAIT);
+        uv::runLoop(uv::defaultLoop(), UV_RUN_NOWAIT);
     }
 
     std::cout << "server running: " << running << std::endl;


### PR DESCRIPTION
The `uv::runLoop()` definition has been changed to default-only arguments, so in order to provide `uv_run_mode`, you must specify the loop which should run. 