### PR TITLE
Fixed websocket handshake issue with latest Firefox

### DIFF
--- a/src/http/src/websocket.cpp
+++ b/src/http/src/websocket.cpp
@@ -427,7 +427,8 @@ void WebSocketFramer::acceptServerRequest(http::Request& request, http::Response
 {
     assert(_mode == ws::ServerSide);
 
-    if (util::icompare(request.get("Connection", ""), "upgrade") == 0 &&
+    if ((util::icompare(request.get("Connection", ""), "upgrade") == 0 ||
+        util::icompare(request.get("Connection", ""), "keep-alive, Upgrade") == 0) &&
         util::icompare(request.get("Upgrade", ""), "websocket") == 0) {
         std::string version = request.get("Sec-WebSocket-Version", "");
         if (version.empty())


### PR DESCRIPTION
I have encountered that websocket handshake is not working with latest Firefox.
The reason is in "Connection" header that is send by Firefox, instead of having value "upgrade", it has "keep-alive, Upgrade". Maybe it is a bit ugly fix, but I didn't want to use find or regular expression to check "Connection" header value in single statement for multiple browsers, in order to avoid any potential issues with using word "upgrade" inside "Connection" header.