### PR TITLE
Fix logic error when calling _encoder.init()

### DIFF
--- a/src/webrtc/include/scy/webrtc/streamrecorder.h
+++ b/src/webrtc/include/scy/webrtc/streamrecorder.h
@@ -50,6 +50,7 @@ protected:
     rtc::scoped_refptr<webrtc::AudioTrackInterface> _audioTrack;
     bool _awaitingVideo;
     bool _awaitingAudio;
+    bool _shouldInit = true;
 };
 
 

--- a/src/webrtc/src/streamrecorder.cpp
+++ b/src/webrtc/src/streamrecorder.cpp
@@ -81,8 +81,15 @@ void StreamRecorder::OnFrame(const webrtc::VideoFrame& yuvframe)
         ivideo.pixelFmt = "yuv420p";
         ivideo.fps = 25;
 
-        if (!_awaitingAudio)
-            _encoder.init();
+        if (_shouldInit) {
+            try {
+                _encoder.init();
+                _shouldInit = false;
+            } catch (std::exception& exc) {
+              LError("Failed to init encoder: ", exc.what())
+              _encoder.uninit();
+            }
+        }
     }
 
     if (_encoder.isActive()) {
@@ -132,8 +139,15 @@ void StreamRecorder::OnData(const void* audio_data, int bits_per_sample,
         // format. Set an assertion just incase this ever changes or varies.
         assert(bits_per_sample == 16);
 
-        if (!_awaitingVideo)
-            _encoder.init();
+        if (_shouldInit) {
+            try {
+                _encoder.init();
+                _shouldInit = false;
+            } catch (std::exception& exc) {
+                LError("Failed to init encoder: ", exc.what())
+                _encoder.uninit();
+            }
+        }
     }
 
     if (_encoder.isActive())


### PR DESCRIPTION
Currently `StreamRecorder` never calls `_encoder.init()` when recording both video and audio tracks. Specifically, `StreamRecorder` expects one of the booleans to be true and the other to be false exactly once so that it can call the `init` function, however in my observations both values start as true then both flip to false.

This PR separates out the init logic from `_awaitingVideo` and `_awaitingAudio` to call `init` exactly once.