### PR TITLE
Update Dockerfile for FFmpeg and introduce support for x86

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM ubuntu:14.04
+# Use IMAGE to select the docker image to build from.
+# For i386 builds:
+# docker build --build-arg IMAGE=i386/ubuntu:18.04 -tmichaelfig/libsourcey:v1.1.4-i386 .
+ARG IMAGE=ubuntu:18.04
+FROM ${IMAGE}
 MAINTAINER Kam Low <hello@sourcey.com>
 
-# Install the PPA for GCC 6 which is required for C++14
-RUN apt-get update && \
-  apt-get install -y software-properties-common && \
-	add-apt-repository -y ppa:ubuntu-toolchain-r/test
+# We need IMAGE again to influence the build.
+ARG IMAGE=ubuntu:18.04
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
@@ -15,27 +17,29 @@ RUN apt-get update && apt-get install -y \
   cmake \
   libx11-dev \
   libglu1-mesa-dev \
-  gcc-6 \
-  g++-6
-
-# Use GCC 6
-RUN sudo update-alternatives \
-  --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 \
-  --slave /usr/bin/g++ g++ /usr/bin/g++-6
+  gcc g++ \
+  libssl-dev \
+  libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libswresample-dev libpostproc-dev
 
 # Download and extract precompiled WebRTC static libraries
 # COPY vendor/webrtc-22215-ab42706-linux-x64 /vendor/webrtc-22215-ab42706-linux-x64
-RUN mkdir -p /vendor/webrtc-22215-ab42706-linux-x64; \
-  curl -sSL https://github.com/sourcey/webrtc-precompiled-builds/raw/master/webrtc-22215-ab42706-linux-x64.tar.gz | sudo tar -xzC /vendor/webrtc-22215-ab42706-linux-x64
+RUN case "$IMAGE" in \
+  *86*) dir=webrtc-22215-ab42706-linux-x86 ;; \
+  *) dir=webrtc-22215-ab42706-linux-x64 ;; \
+  esac; \
+  mkdir -p /vendor/$dir; \
+  curl -sSL https://github.com/sourcey/webrtc-precompiled-builds/raw/master/$dir.tar.gz | tar -xzC /vendor/$dir
 
 # Install LibSourcey
-RUN git clone https://github.com/sourcey/libsourcey.git && \
+#RUN git clone https://github.com/sourcey/libsourcey.git && \
+COPY . libsourcey
+RUN dir=`ls -d /vendor/webrtc-*` && case "$dir" in *x86) export LDFLAGS=-m32; def=" -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_C_FLAGS=-m32";; esac && echo "WebRTC in $dir$def" && \
   cd /libsourcey && mkdir build && cd build && \
-  cmake .. -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_SHARED_LIBS=OFF -DBUILD_WITH_STATIC_CRT=ON \
+  cmake -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_SHARED_LIBS=OFF -DBUILD_WITH_STATIC_CRT=ON \
            -DBUILD_MODULES=ON -DBUILD_APPLICATIONS=OFF -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF \
-           -DWITH_FFMPEG=OFF -DWITH_WEBRTC=ON -DENABLE_LOGGING=OFF \
-           -DWEBRTC_ROOT_DIR=/vendor/webrtc-22215-ab42706-linux-x64 \
-           -DCMAKE_INSTALL_PREFIX=/libsourcey/install && \
+           -DWITH_FFMPEG=ON -DWITH_WEBRTC=ON -DENABLE_LOGGING=OFF \
+           -DWEBRTC_ROOT_DIR="$dir" -DDOCKER_IMAGE="$IMAGE"$def \
+           -DCMAKE_INSTALL_PREFIX=/libsourcey/install .. && \
   make VERBOSE=1 && \
   make install
   # cachebust

--- a/cmake/FindLibSourcey.cmake
+++ b/cmake/FindLibSourcey.cmake
@@ -62,8 +62,7 @@ set(LibSourcey_ALL_MODULES
 )
 
 # Check for cached results. If there are then skip the costly part.
-# FIXME: (michaelfig) I needed to do this, or else include path was not set correctly.
-set_module_notfound(LibSourcey)
+# set_module_notfound(LibSourcey)
 if (NOT LibSourcey_FOUND)
   if(WIN32 AND MSVC)
     set(LibSourcey_MULTI_CONFIGURATION TRUE)

--- a/cmake/FindLibSourcey.cmake
+++ b/cmake/FindLibSourcey.cmake
@@ -62,7 +62,8 @@ set(LibSourcey_ALL_MODULES
 )
 
 # Check for cached results. If there are then skip the costly part.
-# set_module_notfound(LibSourcey)
+# FIXME: (michaelfig) I needed to do this, or else include path was not set correctly.
+set_module_notfound(LibSourcey)
 if (NOT LibSourcey_FOUND)
   if(WIN32 AND MSVC)
     set(LibSourcey_MULTI_CONFIGURATION TRUE)

--- a/cmake/FindWebRTC.cmake
+++ b/cmake/FindWebRTC.cmake
@@ -51,6 +51,10 @@ if(WEBRTC_INCLUDE_DIR)
       ${WEBRTC_ROOT_DIR}/out/x64/Debug
       ${WEBRTC_ROOT_DIR}/out/Debug_x64
       ${WEBRTC_ROOT_DIR}/out/Debug-x64
+      ${WEBRTC_ROOT_DIR}/lib/x86/Debug
+      ${WEBRTC_ROOT_DIR}/out/x86/Debug
+      ${WEBRTC_ROOT_DIR}/out/Debug_x86
+      ${WEBRTC_ROOT_DIR}/out/Debug-x86
       ${WEBRTC_ROOT_DIR}/out/Debug)
 
   find_existing_directory(release_dir
@@ -58,6 +62,10 @@ if(WEBRTC_INCLUDE_DIR)
       ${WEBRTC_ROOT_DIR}/out/x64/Release
       ${WEBRTC_ROOT_DIR}/out/Release_x64
       ${WEBRTC_ROOT_DIR}/out/Release-x64
+      ${WEBRTC_ROOT_DIR}/lib/x86/Release
+      ${WEBRTC_ROOT_DIR}/out/x86/Release
+      ${WEBRTC_ROOT_DIR}/out/Release_x86
+      ${WEBRTC_ROOT_DIR}/out/Release-x86
       ${WEBRTC_ROOT_DIR}/out/Release)
 
   # Attempt to find the monolithic library built with `webrtcbuilds`


### PR DESCRIPTION
Hi!

I'm getting back into LibSourcey as finally my WebRTC application (using https://mediasoup.org on the server side) is gaining some traction.  I'd like to stream to a Mediasoup room from an Linux x86-based device.

To do this, I needed to install FFmpeg, and noticed that Ubuntu bionic (18.04) has all the libraries I need.  I updated the Dockerfile to use bionic and FFmpeg, which I think should be nice for other people, too and is pushed to https://hub.docker.com/r/michaelfig/libsourcey/

My x86 Docker support is hampered by no linux-x86 build corresponding to the webrtc-precompiled-builds used by x64 in the Dockerfile.  LibSourcey v1.1.4 appears not to compile with the latest x86 webrtc-precompiled-build.  Help with that would be appreciated.

Have fun!
Michael.