### PR TITLE
Reply to WebSocket Ping packets with Pong.

### DIFF
--- a/src/http/src/websocket.cpp
+++ b/src/http/src/websocket.cpp
@@ -262,6 +262,13 @@ void WebSocketAdapter::onSocketRecv(net::Socket&, const MutableBuffer& buffer, c
                 if (offset < total)
                     LTrace("Splitting joined packet at ",  offset,  " of ", total)
 
+                if (framer.frameFlags() == unsigned(ws::Opcode::Ping)) {
+                    // Should reply immediately.
+                    LTrace("Replying to ping length ", payloadLength);
+                    send(payload, payloadLength, unsigned(ws::Opcode::Pong));
+                    continue;
+                }
+                
                 // Drop empty packets
                 if (!payloadLength) {
                     LDebug("Dropping empty frame")


### PR DESCRIPTION
LibSourcey's WebSocket implementation should automatically reply to Ping packets with a Pong of the same payload, as per the spec.  This change implements that functionality, as well as allowing for Ping/Pong payloads of length 0.
