### PR TITLE
Expose _config (for STUN/TURN servers), and upgrade to offerAnswerOptions()

### DIFF
--- a/src/webrtc/include/scy/webrtc/peer.h
+++ b/src/webrtc/include/scy/webrtc/peer.h
@@ -78,6 +78,8 @@ public:
     std::string peerid() const;
     std::string token() const;
     webrtc::FakeConstraints& constraints();
+    webrtc::PeerConnectionInterface::RTCConfiguration& config();
+    webrtc::PeerConnectionInterface::RTCOfferAnswerOptions& offerAnswerOptions();
     webrtc::PeerConnectionFactoryInterface* factory() const;
     rtc::scoped_refptr<webrtc::PeerConnectionInterface> peerConnection() const;
     rtc::scoped_refptr<webrtc::MediaStreamInterface> stream() const;
@@ -110,6 +112,7 @@ protected:
     Mode _mode;
     webrtc::PeerConnectionInterface::RTCConfiguration _config;
     webrtc::FakeConstraints _constraints;
+    webrtc::PeerConnectionInterface::RTCOfferAnswerOptions _offerAnswerOptions;
     rtc::scoped_refptr<webrtc::PeerConnectionInterface> _peerConnection;
     rtc::scoped_refptr<webrtc::MediaStreamInterface> _stream;
     std::unique_ptr<cricket::BasicPortAllocator> _portAllocator;


### PR DESCRIPTION
peer->config() is useful for adding STUN/TURN servers without modifying LibSourcey.

OfferAnswerOptions replaces constraints in newer libwebrtc.
