### PR TITLE
Fixed C++ build error "narrowing conversion"

### DIFF
--- a/src/base/src/base64.cpp
+++ b/src/base/src/base64.cpp
@@ -134,7 +134,7 @@ ssize_t encode_blockend(char* code_out, encodestate* state_in)
 
 ssize_t decode_value(char value_in)
 {
-    static const char decoding[] = {
+    static const signed char decoding[] = {
         62, -1, -1, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1,
         -1, -1, -2, -1, -1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
         10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,


### PR DESCRIPTION
Compiling on raspberry pi (armv7), i got
`error: narrowing conversion of '-1' from 'int' to 'char'`

This commit fixes the issue.