### PR TITLE
Support newer ffmpeg versions

### DIFF
--- a/src/av/include/scy/av/ffmpeg.h
+++ b/src/av/include/scy/av/ffmpeg.h
@@ -27,6 +27,11 @@ extern "C" {
 #endif
 }
 
+
+#define LIBAVCODEC_VERSION_CHECK( a, b, c, d, e ) \
+    ( (LIBAVCODEC_VERSION_MICRO <  100 && LIBAVCODEC_VERSION_INT >= AV_VERSION_INT( a, b, c ) ) || \
+          (LIBAVCODEC_VERSION_MICRO >= 100 && LIBAVCODEC_VERSION_INT >= AV_VERSION_INT( a, d, e ) ) )
+
 #endif
 
 

--- a/src/av/src/audioencoder.cpp
+++ b/src/av/src/audioencoder.cpp
@@ -138,7 +138,6 @@ void AudioEncoder::create()
             ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
         #else
             ctx->flags |= CODEC_FLAG_GLOBAL_HEADER;
-
         #endif
     }
 

--- a/src/av/src/audioencoder.cpp
+++ b/src/av/src/audioencoder.cpp
@@ -133,8 +133,14 @@ void AudioEncoder::create()
 
     // Some container formats (like MP4) require global headers to be present
     // Mark the encoder so that it behaves accordingly.
-    if (format && format->oformat->flags & AVFMT_GLOBALHEADER)
-        ctx->flags |= CODEC_FLAG_GLOBAL_HEADER;
+    if (format && format->oformat->flags & AVFMT_GLOBALHEADER) {
+        #if LIBAVCODEC_VERSION_CHECK(52, 30, 2, 30, 2)
+            ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+        #else
+            ctx->flags |= CODEC_FLAG_GLOBAL_HEADER;
+
+        #endif
+    }
 
     // Open the encoder for the audio stream to use it later.
     if ((err = avcodec_open2(ctx, codec, nullptr)) < 0) {

--- a/src/av/src/videoencoder.cpp
+++ b/src/av/src/videoencoder.cpp
@@ -118,7 +118,12 @@ void VideoEncoder::create()
             // TODO: Use oparams.quality to determine values
             // ctx->mb_lmin        = ctx->lmin = ctx->qmin * FF_QP2LAMBDA;
             // ctx->mb_lmax        = ctx->lmax = ctx->qmax * FF_QP2LAMBDA;
-            ctx->flags = CODEC_FLAG_QSCALE;
+            #if LIBAVCODEC_VERSION_CHECK(52, 30, 2, 30, 2)
+                ctx->flags |= AV_CODEC_FLAG_QSCALE;
+            #else
+                ctx->flags |= CODEC_FLAG_QSCALE;
+            #endif
+
             ctx->global_quality = ctx->qmin * FF_QP2LAMBDA;
             break;
         case AV_CODEC_ID_MPEG2VIDEO:
@@ -129,8 +134,13 @@ void VideoEncoder::create()
     }
 
     // Some formats want stream headers to be separate
-    if (format && format->oformat->flags & AVFMT_GLOBALHEADER)
-        ctx->flags |= CODEC_FLAG_GLOBAL_HEADER;
+    if (format && format->oformat->flags & AVFMT_GLOBALHEADER) {
+        #if LIBAVCODEC_VERSION_CHECK(52, 30, 2, 30, 2)
+            ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+        #else
+            ctx->flags |= CODEC_FLAG_GLOBAL_HEADER;
+        #endif
+    }
 
     // Allocate the input frame
     frame = createVideoFrame(av_get_pix_fmt(iparams.pixelFmt.c_str()),


### PR DESCRIPTION
In newer versions of ffmpeg, constant names have been prefixed by "AV_". A macro was defined to check for the ffmpeg version we build against. The macro is used where the new constant names break the build.