### PR TITLE
Conan Center: Support shared compilation in Windows

### DIFF
--- a/src/av/include/icy/av/packet.h
+++ b/src/av/include/icy/av/packet.h
@@ -25,7 +25,7 @@ namespace av {
 
 
 /// Timestamped media packet carrying raw audio or video data
-struct MediaPacket : public RawPacket
+struct AV_API MediaPacket : public RawPacket
 {
     int64_t time; ///< Presentation timestamp in microseconds.
 
@@ -66,7 +66,7 @@ struct MediaPacket : public RawPacket
 
 
 /// Video packet for interleaved formats
-struct VideoPacket : public MediaPacket
+struct AV_API VideoPacket : public MediaPacket
 {
     int width;    ///< Frame width in pixels.
     int height;   ///< Frame height in pixels.
@@ -118,7 +118,7 @@ struct VideoPacket : public MediaPacket
 /// @param width     The frame width in pixels.
 /// @param height    The frame height in pixels.
 /// @param time      The timestamp in microseconds.
-struct PlanarVideoPacket : public VideoPacket
+struct AV_API PlanarVideoPacket : public VideoPacket
 {
     uint8_t* buffer[4] = {nullptr};
     int linesize[4] = {0};
@@ -151,7 +151,7 @@ struct PlanarVideoPacket : public VideoPacket
 
 
 /// Audio packet for interleaved formats
-struct AudioPacket : public MediaPacket
+struct AV_API AudioPacket : public MediaPacket
 {
     size_t numSamples; ///< Number of audio samples per channel.
 
@@ -194,7 +194,7 @@ struct AudioPacket : public MediaPacket
 /// @param numSamples  The number of samples per channel.
 /// @param sampleFmt   The sample format name (e.g. "fltp").
 /// @param time        The timestamp in microseconds.
-struct PlanarAudioPacket : public AudioPacket
+struct AV_API PlanarAudioPacket : public AudioPacket
 {
     uint8_t* buffer[4] = {nullptr};
     int linesize = 0;

--- a/src/av/include/icy/av/videoconverter.h
+++ b/src/av/include/icy/av/videoconverter.h
@@ -29,7 +29,7 @@ namespace av {
 
 
 /// Converts video frames between pixel formats and resolutions
-struct VideoConverter
+struct AV_API VideoConverter
 {
     VideoConverter();
     virtual ~VideoConverter() noexcept;


### PR DESCRIPTION
## Windows shared library build (`BUILD_SHARED_LIBS=ON`)

Hi,
I'm a maintainer of [Conan](https://github.com/conan-io/conan) and [Conan Center Index](https://github.com/conan-io/conan-center-index). We are adding **icey** to Conan Center; our packaging PR is here:
https://github.com/conan-io/conan-center-index/pull/29896

CCI builds icey on Linux, macOS, and Windows, for both static and shared libraries. 
On **Windows with shared libraries**, the build fails unless we apply a small patch to export a few `av` types across DLL boundaries.


### Failure without the patch

When building with MSVC and `BUILD_SHARED_LIBS=ON` (and optionally `-DWITH_FFMPEG=ON`), compilation gets through `vision` but **linking `icy_vision.dll` fails**.

Typical compiler warning (also seen when `VisionFramePacket` inherits from `PlanarVideoPacket`):
```text
src\vision\include\icy\vision\framepacket.h(25): warning C4275: non dll-interface struct
  'icy::av::PlanarVideoPacket' used as base for dll-interface struct
  'icy::vision::VisionFramePacket'
src\av\include\icy\av\packet.h(121): note: see declaration of 'icy::av::PlanarVideoPacket'
src\vision\include\icy\vision\framepacket.h(25): note: see declaration of 'icy::vision::VisionFramePacket'
Link step (example from icy_vision.dll):

[140/140] Linking CXX shared library vision\icy_vision.dll
FAILED: vision/icy_vision.dll vision/icy_vision.lib
...
vision\CMakeFiles\vision.dir\src\framepacket.cpp.obj
vision\CMakeFiles\vision.dir\src\framenormalizer.cpp.obj
...
```

Unresolved symbols (representative; exact list depends on WITH_FFMPEG):
```
error LNK2019: unresolved external symbol "public: __cdecl icy::av::PlanarVideoPacket::PlanarVideoPacket(
  class icy::av::PlanarVideoPacket const &)" (??0PlanarVideoPacket@av@icy@@QEAA@AEBV012@@Z)
  referenced in function "public: __cdecl icy::vision::VisionFramePacket::VisionFramePacket(
  class icy::av::PlanarVideoPacket const &,struct icy::vision::VisionFrameContext)"
```


With FFmpeg enabled (WITH_FFMPEG=ON), FrameNormalizer also needs symbols from icy_av.dll for VideoConverter:
```
error LNK2019: unresolved external symbol "public: __cdecl icy::av::VideoConverter::VideoConverter(void)"
error LNK2019: unresolved external symbol "public: virtual __cdecl icy::av::VideoConverter::~VideoConverter(void)"
error LNK2019: unresolved external symbol "public: virtual void __cdecl icy::av::VideoConverter::create(void)"
error LNK2019: unresolved external symbol "public: virtual void __cdecl icy::av::VideoConverter::close(void)"
error LNK2019: unresolved external symbol "public: virtual struct AVFrame * __cdecl icy::av::VideoConverter::convert(struct AVFrame *)"
Static builds on Windows are fine. The issue is cross-DLL use: vision exports Vision_API types that inherit from or embed av types whose out-of-line methods live in icy_av.dll but are not marked with AV_API / __declspec(dllexport).
```


### Workaround we use in Conan Center

We are applying a patch that adds `AV_API` to the media packet hierarchy in `src/av/include/icy/av/packet.h` and to `VideoConverter` in `src/av/include/icy/av/videoconverter.h` (same change as in our CCI PR, not yet merged).

We would prefer to drop that patch once upstream fixes Windows shared builds, so CCI can consume a clean release tag.
