### PR TITLE
fix: keep Doxyfile version in release sync

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "icey"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.4.10
+PROJECT_NUMBER         = 2.5.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -37,6 +37,8 @@ docs=(
 
 current_version=$(tr -d '[:space:]' < VERSION)
 [ "$current_version" = "$version" ] || fail "VERSION contains $current_version, expected $version"
+grep -Eq '^PROJECT_NUMBER[[:space:]]*=[[:space:]]*'"$version"'$' Doxyfile \
+    || fail "Doxyfile PROJECT_NUMBER is not synced to $version"
 
 grep -Eq '^    version = "'"$version"'"$' packaging/conan/conanfile.py \
     || fail "packaging/conan/conanfile.py is not synced to $version"

--- a/scripts/release-sync.sh
+++ b/scripts/release-sync.sh
@@ -31,6 +31,7 @@ docs=(
 )
 
 printf '%s\n' "$version" > VERSION
+perl -0pi -e 's/^PROJECT_NUMBER[[:space:]]*=.*$/PROJECT_NUMBER         = '"$version"'/m' Doxyfile
 
 perl -0pi -e 's/version = "\d+\.\d+\.\d+"/version = "'"$version"'"/' packaging/conan/conanfile.py
 cat > packaging/conan/conandata.yml <<EOF


### PR DESCRIPTION
## Summary
- update Doxyfile PROJECT_NUMBER to the current 2.5.0 release
- include Doxyfile in release-sync so future release prep updates it
- include Doxyfile in release-check so version drift is caught before release finalization

## Verification
- bash -n scripts/release-sync.sh scripts/release-check.sh
- ./scripts/release-check.sh 2.5.0
